### PR TITLE
Fix #1: module resolution for tsc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 node_modules
 *.js
 *.map
-tsconfig.json
 dist

--- a/README.md
+++ b/README.md
@@ -9,18 +9,21 @@ Customizable slimScroll directive for Angular 2.
 You'll need to add `SlimScroll` to your application module.
 
 ```typescript
+import { SlimScroll } from 'angular-io-slimscroll';
+
 @NgModule({
   declarations: [
+    SlimScroll,
     AppComponent
   ],
   imports: [
-    SlimScroll,
     ...
   ],
-  providers: [],
+  providers: [
+    ...
+  ],
   bootstrap: [AppComponent]
 })
-
 export class AppModule {
 }
 ```

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./src/slimscroll.directive.ts",
   "typings": "./src/slimscroll.directive.ts",
   "scripts": {
-    "start": "tsc -w"
+    "prepublish": "tsc -p src/"
   },
   "keywords": [
     "angular",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Slim scroll directive for angular2",
   "main": "./src/slimscroll.directive.ts",
+  "typings": "./src/slimscroll.directive.ts",
   "scripts": {
     "start": "tsc -w"
   },

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "lib": [ "es2015", "dom" ],
+    "noImplicitAny": true,
+    "suppressImplicitAnyIndexErrors": true
+  }
+}


### PR DESCRIPTION
Fix #1:
+ Ensure **tsc** compiler locates the directive:
Cf. Typescript's [module resolution](https://github.com/Microsoft/TypeScript-Handbook/blob/master/pages/Module%20Resolution.md).

+ Add prepublish step for transpiling/bundling to commonJS.
Cf. [How to publish a library for Angular 2 on npm](https://medium.com/@OCombe/how-to-publish-a-library-for-angular-2-on-npm-5f48cdabf435)